### PR TITLE
Support dynamic arguments

### DIFF
--- a/exunit.el
+++ b/exunit.el
@@ -181,7 +181,10 @@ and filename relative to the dependency."
 (defun exunit-compile (args &optional directory)
   "Run mix test with the given ARGS."
   (let ((default-directory (or directory (exunit-project-root)))
-        (compilation-environment exunit-environment))
+        (compilation-environment exunit-environment)
+        (args (if current-prefix-arg
+                  `(,(read-from-minibuffer "Args: " (s-join " " args) nil nil 'exunit-arguments))
+                args)))
     (exunit-do-compile
      (s-join " " (append '("mix" "test") exunit-mix-test-default-options args)))))
 


### PR DESCRIPTION
Fixes #9.

Sometimes I want to run `mix test` with custom command-line arguments (e.g. `mix test --exclude test --include api` to run only tests tagged "api").

This PR adds the ability to do that by invoking the `exunit-verify-*` commands with a prefix argument (e.g. `C-u C-c , s`). The user will be prompted for their custom command-line arguments, with the default being whatever default arguments they have configured.